### PR TITLE
resolves potential conflicts w/ other addons using moment (fixes #6)

### DIFF
--- a/blueprints/full-calendar/index.js
+++ b/blueprints/full-calendar/index.js
@@ -4,7 +4,7 @@ module.exports = {
   afterInstall: function() {
     var _this = this;
     return this.addBowerPackageToProject('fullcalendar').then(function() {
-      return _this.addBowerPackageToProject('momentjs');
+      return this.addAddonToProject('ember-cli-moment-shim', '0.6.2');
     });
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,6 @@
     "qunit": "~1.17.1"
   },
   "devDependencies": {
-    "fullcalendar": "~2.3.1"
+    "fullcalendar": "~2.4.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -6,8 +6,7 @@ module.exports = {
 
   included: function(app) {
     this._super.included(app);
-
-		app.import(app.bowerDirectory + '/moment/min/moment.min.js')
+    
     app.import(app.bowerDirectory + '/fullcalendar/dist/fullcalendar.min.js');
     app.import(app.bowerDirectory + '/fullcalendar/dist/fullcalendar.min.css');
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-full-calendar",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "An Ember wrapper for jQuery FullCalendar.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
This PR resolves an issue where other Ember CLI addons using the Moment library can cause Moment plugins, such as timezone or locale, to not function. It uses @jasonmit's [ember-cli-moment-shim](https://github.com/jasonmit/ember-cli-moment-shim) addon to handle loading of Moment. 

See [this issue](https://github.com/stefanpenner/ember-moment/issues/110) for more information.

This also bumps the Fullcalendar dependency to the latest.