### PR TITLE
Added `timezone` FullCalendar property support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Use the `full-calendar` component -
 * [scrollTime](http://fullcalendar.io/docs/agenda/scrollTime/)
 * [slotEventOverlap](http://fullcalendar.io/docs/agenda/slotEventOverlap/)
 * [businessHours](http://fullcalendar.io/docs/display/businessHours/)
+* [timezone](http://http://fullcalendar.io/docs/timezone/timezone/)
 
 ### Supported Callbacks
 

--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -67,6 +67,9 @@ export default Ember.Component.extend({
       defaultView: _this.get('defaultView'),
       businessHours: _this.get('businessHours'),
 
+      // Timezone
+      timezone: _this.get('timezone'),
+
       // Agenda Option
       minTime: _this.get('minTime'),
       maxTime: _this.get('maxTime'),


### PR DESCRIPTION
Added support for `timezone` property so timezones already setup via Moment are not lost.  (See http://fullcalendar.io/docs/timezone/timezone/)