### PR TITLE
do not use minified files

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ module.exports = {
 
   included: function(app) {
     this._super.included(app);
-    
-    app.import(app.bowerDirectory + '/fullcalendar/dist/fullcalendar.min.js');
-    app.import(app.bowerDirectory + '/fullcalendar/dist/fullcalendar.min.css');
+
+    app.import(app.bowerDirectory + '/fullcalendar/dist/fullcalendar.js');
+    app.import(app.bowerDirectory + '/fullcalendar/dist/fullcalendar.css');
   }
 };


### PR DESCRIPTION
It's easier for debugging purposes if we include the non-minified sources.

This way, we benefit from source maps and they will be eventually minified by ember-cli anyway.