### PR TITLE
add 'nowIndicator' option

### DIFF
--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -19,6 +19,7 @@ export default Ember.Component.extend({
   height                : 'auto',
   businessHours         : false,
   nowIndicator          : false,
+  allDaySlot            : true,
 
   // Views
   defaultView           : 'month',
@@ -71,6 +72,7 @@ export default Ember.Component.extend({
       businessHours: _this.get('businessHours'),
       titleFormat: _this.get('titleFormat'),
       nowIndicator: _this.get('nowIndicator'),
+      allDaySlot: _this.get('allDaySlot'),
 
       // Timezone
       timezone: _this.get('timezone'),

--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -20,6 +20,8 @@ export default Ember.Component.extend({
   businessHours         : false,
   nowIndicator          : false,
   allDaySlot            : true,
+  eventLimit            : false,
+  eventLimitClick       : 'popover',
 
   // Views
   defaultView           : 'month',
@@ -73,6 +75,8 @@ export default Ember.Component.extend({
       titleFormat: _this.get('titleFormat'),
       nowIndicator: _this.get('nowIndicator'),
       allDaySlot: _this.get('allDaySlot'),
+      eventLimit: _this.get('eventLimit'),
+      eventLimitClick: _this.get('eventLimitClick'),
 
       // Timezone
       timezone: _this.get('timezone'),

--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -18,6 +18,7 @@ export default Ember.Component.extend({
   weekNumbers           : false,
   height                : 'auto',
   businessHours         : false,
+  nowIndicator          : false,
 
   // Views
   defaultView           : 'month',
@@ -69,6 +70,7 @@ export default Ember.Component.extend({
       defaultView: _this.get('defaultView'),
       businessHours: _this.get('businessHours'),
       titleFormat: _this.get('titleFormat'),
+      nowIndicator: _this.get('nowIndicator'),
 
       // Timezone
       timezone: _this.get('timezone'),

--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,6 @@
     "qunit": "~1.20.0"
   },
   "devDependencies": {
-    "fullcalendar": "~2.4.0"
+    "fullcalendar": "~2.6.0"
   }
 }


### PR DESCRIPTION
available in fullcalendar 2.6, update dev dependency to use fullcalendar 2.6

http://fullcalendar.io/docs/current_date/nowIndicator/
