### PR TITLE
Travis fail fix

### DIFF
--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -78,7 +78,7 @@ export default Component.extend({
       businessHours: this.get('businessHours'),
       titleFormat: this.get('titleFormat'),
 
-      viewRender(view, element) => {
+      viewRender: (view, element) => {
         this.sendAction('viewRender', view, element);
       },
 
@@ -99,56 +99,56 @@ export default Component.extend({
       lang: this.get('lang'),
 
       // Clicking & Hovering
-      dayClick(date, jsEvent, view) => {
+      dayClick: (date, jsEvent, view) => {
         this.sendAction('dayClick', date, jsEvent, view);
       },
 
-      eventClick(calEvent, jsEvent, view) => {
+      eventClick: (calEvent, jsEvent, view) => {
         this.sendAction('eventClick', calEvent, jsEvent, view);
       },
 
-      eventDragStart(event, jsEvent, ui, view) => {
+      eventDragStart: (event, jsEvent, ui, view) => {
         this.sendAction('eventDragStart', event, jsEvent, ui, view);
       },
 
-      eventDragStop(event, jsEvent, ui, view) => {
+      eventDragStop: (event, jsEvent, ui, view) => {
         this.sendAction('eventDragStop', event, jsEvent, ui, view);
       },
 
-      eventDrop(event, delta, revertFunc, jsEvent, ui, view) => {
+      eventDrop: (event, delta, revertFunc, jsEvent, ui, view) => {
         this.sendAction('eventDrop', event, delta, revertFunc, jsEvent, ui, view);
       },
 
-      eventResize(event, delta, revertFunc, jsEvent, ui, view) => {
+      eventResize: (event, delta, revertFunc, jsEvent, ui, view) => {
         this.sendAction('eventResize', event, delta, revertFunc, jsEvent, ui, view);
       },
 
-      eventResizeStart(event, jsEvent, ui, view) => {
+      eventResizeStart: (event, jsEvent, ui, view) => {
         this.sendAction('eventResizeStart', event, jsEvent, ui, view);
       },
 
-      eventResizeStop(event, jsEvent, ui, view) => {
+      eventResizeStop: (event, jsEvent, ui, view) => {
         this.sendAction('eventResizeStop', event, jsEvent, ui, view);
       },
 
-      select(start, end, jsEvent, view) => {
+      select: (start, end, jsEvent, view) => {
         this.sendAction('select', start, end, jsEvent, view);
       },
 
       // Event Rendering
-      eventRender(event, element, view) => {
+      eventRender: (event, element, view) => {
         this.sendAction('eventRender', event, element, view);
       },
 
-      eventAfterRender(event, element, view ) => {
+      eventAfterRender: (event, element, view ) => {
         this.sendAction('eventAfterRender', event, element, view);
       },
 
-      eventAfterAllRender(view) => {
+      eventAfterAllRender: (view) => {
         this.sendAction('eventAfterAllRender', view);
       },
 
-      eventDestroy(event, element, view) => {
+      eventDestroy: (event, element, view) => {
         this.sendAction('eventDestroy', event, element, view);
       },
 

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0"
   },


### PR DESCRIPTION
Lock jQuery to 1.11.3 because 1.12.x has a problem and doesn't work with ember correctly.
More info here: https://github.com/ember-cli/ember-cli/issues/5316