### PR TITLE
Event rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,29 +48,9 @@ Use the `full-calendar` component -
 * [lang](http://fullcalendar.io/docs/text/lang/)
 * [timeFormat](http://fullcalendar.io/docs/text/timeFormat/)
 
-### Timezone
-* [timezone](http://fullcalendar.io/docs/timezone/timezone/)
-* [now](http://fullcalendar.io/docs/timezone/now/)
+### Sending Actions to calendar
 
-### Agenda Options
-
-* [allDaySlot](http://fullcalendar.io/docs/agenda/allDaySlot/)
-* [allDayText](http://fullcalendar.io/docs/agenda/allDayText/)
-* [maxTime](http://fullcalendar.io/docs/agenda/maxTime/)
-* [minTime](http://fullcalendar.io/docs/agenda/minTime/)
-* [scrollTime](http://fullcalendar.io/docs/agenda/scrollTime/)
-* [slotEventOverlap](http://fullcalendar.io/docs/agenda/slotEventOverlap/)
-* [slotLabelFormat](http://fullcalendar.io/docs/timeline/slotLabelFormat/)
-* [slotLabelInterval](http://fullcalendar.io/docs/agenda/slotLabelInterval/)
-* [snapDuration](http://fullcalendar.io/docs/agenda/snapDuration/)
-
-### Current Date
-
-* [defaultDate](http://fullcalendar.io/docs/current_date/defaultDate/)
-
-### Current Date Actions
-
-For the actions to work we need to register a property that will allow as to access FullCalendar element from our controller.
+For the actions to work we need to register a property that will allow us to access FullCalendar element from our controller.
 
 
 ```
@@ -99,7 +79,27 @@ export default Ember.Controller.extend({
 });
 ```
 
-##### Available actions
+### Timezone
+* [timezone](http://fullcalendar.io/docs/timezone/timezone/)
+* [now](http://fullcalendar.io/docs/timezone/now/)
+
+### Agenda Options
+
+* [allDaySlot](http://fullcalendar.io/docs/agenda/allDaySlot/)
+* [allDayText](http://fullcalendar.io/docs/agenda/allDayText/)
+* [maxTime](http://fullcalendar.io/docs/agenda/maxTime/)
+* [minTime](http://fullcalendar.io/docs/agenda/minTime/)
+* [scrollTime](http://fullcalendar.io/docs/agenda/scrollTime/)
+* [slotEventOverlap](http://fullcalendar.io/docs/agenda/slotEventOverlap/)
+* [slotLabelFormat](http://fullcalendar.io/docs/timeline/slotLabelFormat/)
+* [slotLabelInterval](http://fullcalendar.io/docs/agenda/slotLabelInterval/)
+* [snapDuration](http://fullcalendar.io/docs/agenda/snapDuration/)
+
+### Current Date
+
+* [defaultDate](http://fullcalendar.io/docs/current_date/defaultDate/)
+
+### Current Date Actions
 
 * [prev](http://fullcalendar.io/docs/current_date/prev/)  
   `this.get('accessToFullCalendar').send('prev')`
@@ -121,6 +121,27 @@ export default Ember.Controller.extend({
 
 Please check dummy app in tests for usage example.
 
+### Event Rendering
+
+* [eventColor](http://fullcalendar.io/docs/event_rendering/Colors/)
+* [eventBackgroundColor](http://fullcalendar.io/docs/event_rendering/eventBackgroundColor/)
+* [eventBorderColor](http://fullcalendar.io/docs/event_rendering/eventBorderColor/)
+* [eventTextColor](http://fullcalendar.io/docs/event_rendering/eventTextColor/)
+* [nextDayThreshold](http://fullcalendar.io/docs/event_rendering/nextDayThreshold/)
+* [eventOrder](http://fullcalendar.io/docs/event_rendering/eventOrder/)
+* [eventRender (callback)](http://fullcalendar.io/docs/event_rendering/eventRender/)
+* [eventAfterRender (callback)](http://fullcalendar.io/docs/event_rendering/eventAfterRender/)
+* [eventAfterAllRender (callback)](http://fullcalendar.io/docs/event_rendering/eventAfterAllRender/)
+* [eventDestroy (callback)](http://fullcalendar.io/docs/event_rendering/eventDestroy/)
+
+### Event Rendering Actions
+
+* [renderEvent (method)](http://fullcalendar.io/docs/event_rendering/renderEvent/)  
+  `this.get('accessToFullCalendar').send('renderEvent', {title: "New Event", start: new Date(2014, 1, 1)})`
+
+* [rerenderEvents (method)](http://fullcalendar.io/docs/event_rendering/rerenderEvents/)  
+  `this.get('accessToFullCalendar').send('rerenderEvents')`
+
 ### Supported Callbacks
 
 * [eventClick](http://fullcalendar.io/docs/mouse/eventClick/)
@@ -130,10 +151,6 @@ Please check dummy app in tests for usage example.
 * [eventResize](http://fullcalendar.io/docs/event_ui/eventResize/)
 * [eventResizeStart](http://fullcalendar.io/docs/event_ui/eventResizeStart/)
 * [eventResizeStop](http://fullcalendar.io/docs/event_ui/eventResizeStop/)
-* [eventRender](http://fullcalendar.io/docs/event_rendering/eventRender/)
-* [eventAfterRender](http://fullcalendar.io/docs/event_rendering/eventAfterRender/)
-* [eventAfterAllRender](http://fullcalendar.io/docs/event_rendering/eventAfterAllRender/)
-* [eventDestroy](http://fullcalendar.io/docs/event_rendering/eventDestroy/)
 * [eventMouseover](http://fullcalendar.io/docs/mouse/eventMouseover/)
 * [eventMouseout](http://fullcalendar.io/docs/mouse/eventMouseout/)
 * [select](http://fullcalendar.io/docs/selection/select_callback/)

--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -45,6 +45,14 @@ export default Component.extend({
   defaultDate: null,
   nowIndicator: false,
 
+  // Event Rendering
+  eventColor: null,
+  eventBackgroundColor: null,
+  eventBorderColor: null,
+  eventTextColor: null,
+  nextDayThreshold: "09:00:00",
+  eventOrder: "title",
+
   // Event Dragging & Resizing
   editable: false,
   eventStartEditable: false,
@@ -117,6 +125,14 @@ export default Component.extend({
 
       // Current Date
       defaultDate: this.get('defaultDate'),
+
+      // Event Rendering
+      eventColor: this.get('eventColor'),
+      eventBackgroundColor: this.get('eventBackgroundColor'),
+      eventBorderColor: this.get('eventBorderColor'),
+      eventTextColor: this.get('eventTextColor'),
+      nextDayThreshold: this.get('nextDayThreshold'),
+      eventOrder: this.get('eventOrder'),
 
       // Text/Time Customization
       lang: this.get('lang'),
@@ -226,6 +242,16 @@ export default Component.extend({
 
     incrementDate: function(duration) {
       this.$().fullCalendar('incrementDate', duration);
-    }
+    },
+
+    // Event Rendering
+    renderEvent: function(event, stick) {
+      this.$().fullCalendar('renderEvent', event, stick);
+    },
+
+    rerenderEvents: function() {
+      this.$().fullCalendar('rerenderEvents');
+    },
+
   }
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   fullCalendar2: null,
+  fullCalendar1: null,
 
   actions: {
     prev: function() {
@@ -30,6 +31,107 @@ export default Ember.Controller.extend({
 
     incrementDate: function() {
       this.get('fullCalendar2').send('incrementDate', {months:1});
+    },
+
+    renderEvent: function() {
+      var date = new Date();
+      date.setHours(0,0,0,0);
+      var dateSeconds = date.getTime();
+      var msInDay = 60 * 60 * 24 * 1000;
+      var msInHour = 60 * 60 * 1000;
+
+      this.get('fullCalendar1').send(
+        'renderEvent',
+        {
+          title: "Event added by button",
+          start: (dateSeconds),
+          end: (dateSeconds + msInHour * 5)
+        }
+      );
+    },
+
+    rerenderEvents: function() {
+      this.get('fullCalendar1').send('rerenderEvents');
     }
-  }
+  },
+
+  events: Ember.computed('', function() {
+    var date = new Date();
+    date.setHours(0,0,0,0);
+    var dateSeconds = date.getTime();
+    var msInDay = 60 * 60 * 24 * 1000;
+    var msInHour = 60 * 60 * 1000;
+    var msInHalfHour = 60 * 30 * 1000;
+
+    var events = [
+      {
+        title: 'All Day Event',
+        start:  date.getFullYear() + '-' +
+                ('0' + (date.getMonth()+1)).slice(-2) + '-' +
+                ('0' + (date.getDate())).slice(-2),
+      },
+      {
+        title: 'Long Event',
+        start: (dateSeconds + msInDay),
+        end: (dateSeconds + msInDay * 5 + msInHour * 4)
+      },
+      {
+        id: 999,
+        title: 'Repeating Event',
+        start: dateSeconds + msInDay * 2
+      },
+      {
+        id: 999,
+        title: 'Repeating Event',
+        start: dateSeconds + msInDay * 4
+      },
+      {
+        title: 'Conference',
+        start: dateSeconds + msInDay * 6,
+        end: dateSeconds + msInDay * 9
+      },
+      {
+        title: 'Meeting',
+        start: dateSeconds + msInDay * 3 + msInHour * 10,
+        end: dateSeconds + msInDay * 3 + msInHour * 12 + msInHalfHour
+      },
+      {
+        title: 'Lunch',
+        start: dateSeconds + msInDay * 3 + msInHour * 14
+      },
+      {
+        title: 'Interview phone call',
+        start: dateSeconds + msInDay * 3 + msInHour * 14
+      },
+      {
+        title: 'Meeting',
+        start: dateSeconds + msInDay * 3 + msInHour * 16  + msInHalfHour
+      },
+
+      {
+        title: 'Happy Hour',
+        start: dateSeconds + msInDay * 3 + msInHour * 18  + msInHalfHour
+      },
+      {
+        title: 'Dinner',
+        start: dateSeconds + msInDay * 3 + msInHour * 19
+      },
+      {
+        title: 'Birthday Party',
+        start: dateSeconds + msInDay * 3 + msInHour * 20
+      }
+    ];
+    return events;
+  }),
+
+  /**
+   * Header setting for full calendar
+   */
+  fcHeader: Ember.computed('', function() {
+    return {
+      left: "month,agendaWeek,agendaDay",
+      center: "",
+      right: "title,today,prev,next"
+    };
+  })
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,20 +2,26 @@
 
 {{outlet}}
 
+  <button {{action 'renderEvent'}}>Add event action</button>
+  <button {{action 'rerenderEvents'}}>Rerender events</button>
+
 {{full-calendar
   events=events
   defaultView="agendaWeek"
   allDayText="Whole day"
-  minTime="08:00"
-  maxTime="20:00"
   scrollTime="00:30"
   slotDuration="00:15"
   slotEventOverlap=false
   slotLabelFormat="HH:mm"
   slotLabelInterval="00:15"
   snapDuration="00:45"
-  now="2013-12-01T00:00:00"
+  header=fcHeader
+  nextDayThreshold="03:00:00"
+  eventOrder="-title"
+  register-as="fullCalendar1"
 }}
+
+  <hr>
 
   <button {{action 'prev'}}>Prev</button>
   <button {{action 'next'}}>Next</button>
@@ -31,5 +37,11 @@
   allDaySlot=false
   register-as="fullCalendar2"
   nowIndicator=true
+  eventColor='yellow'
+  eventBackgroundColor='green'
+  eventTextColor='blue'
+  minTime="08:00"
+  maxTime="20:00"
+  header=fcHeader
 }}
 

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -12,6 +12,9 @@ module.exports = function(environment) {
         // e.g. 'with-controller': true
       }
     },
+    contentSecurityPolicy: {
+      'style-src': "'self' 'unsafe-inline'"
+    },
 
     APP: {
       // Here you can pass flags/options to your application instance


### PR DESCRIPTION
Added all missing options from Event Rendering.
Reorganized README a little. Moved callbacks to Event Rendering.

I think that we can do the same with all other callbacks when adding new stuff from full calendar. It would be good if our README would be organized in the similar way as full calendar.