### PR TITLE
Fix support for nowIndicator.

### DIFF
--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -136,6 +136,9 @@ export default Component.extend({
       // Current Date
       defaultDate: this.get('defaultDate'),
 
+      // nowIndicator
+      nowIndicator: this.get('nowIndicator'),
+
       // Event Rendering
       eventColor: this.get('eventColor'),
       eventBackgroundColor: this.get('eventBackgroundColor'),


### PR DESCRIPTION
Now indicator is defined, but not passed to fullcalendar.