### PR TITLE
Because of ember 2.9 removed targetObject

### DIFF
--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -84,7 +84,8 @@ export default Component.extend({
    * Register this component to parent controller. We need this to be able to send actions from outside.
    */
   didReceiveAttrs: function() {
-    this.set('targetObject.' + this.get('register-as'), this);
+    let targetObject = this.get('targetObject') ? 'targetObject' : '_targetObject';
+    this.set(targetObject + '.' + this.get('register-as'), this);
   },
 
   didInsertElement() {


### PR DESCRIPTION
In the meantime just use _targetObject but
ember team will restore functionality with
a deprecation message:

https://github.com/emberjs/ember.js/issues/14168